### PR TITLE
Adjust mobile timer and turn indicator layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -437,3 +437,52 @@ body {
   border-color: var(--error);
   color: var(--error);
 }
+
+@media (max-width: 480px) {
+  .timer-banner {
+    padding: 10px 12px;
+    gap: 8px;
+    flex-wrap: wrap;
+    min-height: 0;
+  }
+
+  .timer-section {
+    padding: 0 4px;
+    flex: 1 1 50%;
+  }
+
+  .timer-header {
+    gap: 4px;
+    margin-bottom: 4px;
+  }
+
+  .timer-label {
+    font-size: 10px;
+  }
+
+  .timer-value {
+    font-size: 18px;
+    padding: 4px 8px;
+    min-width: 64px;
+  }
+
+  .material-points {
+    font-size: 12px;
+    padding: 2px 6px;
+  }
+
+  .turn-indicator {
+    order: 3;
+    flex-basis: 100%;
+    padding: 4px 0 0;
+  }
+
+  .turn-text {
+    font-size: 10px;
+  }
+
+  .turn-dot {
+    width: 10px;
+    height: 10px;
+  }
+}


### PR DESCRIPTION
Fix timer size on mobile and reposition the turn indicator below timers to improve mobile layout.

---
<a href="https://cursor.com/background-agent?bcId=bc-714ec9a9-fed8-4db1-89f6-494671e36da0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-714ec9a9-fed8-4db1-89f6-494671e36da0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

