### PR TITLE
Game-over banners, idle snark on same-square drop

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,6 +19,15 @@
   --error-bg: rgba(248, 113, 113, 0.1);
   --error-border: rgba(248, 113, 113, 0.3);
 
+  --success: #34d399;
+  --success-bg: rgba(52, 211, 153, 0.12);
+  --success-border: rgba(52, 211, 153, 0.45);
+  --accent-gold: #fbbf24;
+  --draw-bg: rgba(251, 191, 36, 0.1);
+  --draw-border: rgba(251, 191, 36, 0.4);
+  --snark-bg: rgba(148, 163, 184, 0.12);
+  --snark-border: rgba(148, 163, 184, 0.35);
+
   /* Board colors */
   --board-dark-square: #769656;
   --board-light-square: #eeeed2;
@@ -100,6 +109,125 @@ body {
   border: 1px solid var(--error-border);
   font-size: 13px;
   font-weight: 500;
+}
+
+.game-status-root {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.game-over-banner {
+  width: 100%;
+  padding: 20px 20px 18px;
+  border-radius: 12px;
+  border: 2px solid;
+  text-align: center;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.35);
+  animation: game-over-pop 0.45s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@keyframes game-over-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.96) translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+.game-over-banner--checkmate {
+  background: linear-gradient(
+    145deg,
+    rgba(52, 211, 153, 0.18) 0%,
+    var(--card-bg) 55%
+  );
+  border-color: var(--success-border);
+  box-shadow:
+    0 0 0 1px rgba(52, 211, 153, 0.15),
+    0 12px 32px rgba(0, 0, 0, 0.4);
+}
+
+.game-over-banner--stalemate {
+  background: linear-gradient(
+    145deg,
+    rgba(148, 163, 184, 0.2) 0%,
+    var(--card-bg) 60%
+  );
+  border-color: rgba(148, 163, 184, 0.5);
+}
+
+.game-over-banner--draw {
+  background: linear-gradient(
+    145deg,
+    var(--draw-bg) 0%,
+    var(--card-bg) 55%
+  );
+  border-color: var(--draw-border);
+}
+
+.game-over-banner__icon {
+  font-size: 36px;
+  line-height: 1;
+  margin-bottom: 6px;
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.35));
+}
+
+.game-over-banner__title {
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--foreground);
+  margin-bottom: 4px;
+}
+
+.game-over-banner--checkmate .game-over-banner__title {
+  color: var(--success);
+  text-shadow: 0 0 24px rgba(52, 211, 153, 0.35);
+}
+
+.game-over-banner__winner {
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--foreground);
+}
+
+.game-over-banner__sub {
+  font-size: 14px;
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.idle-snark-carousel {
+  width: 100%;
+  padding: 10px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--snark-border);
+  background: var(--snark-bg);
+  animation: snark-slide-in 0.4s ease-out;
+}
+
+@keyframes snark-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.idle-snark-carousel__text {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.45;
+  font-style: italic;
+  color: var(--foreground);
 }
 
 .game-button {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,6 +42,8 @@ export default function Home() {
     fen,
     gameStatus,
     lastError,
+    idleSnarkIndex,
+    idleSnark,
     capturedPieces,
     customSquareStyles,
     whiteTime,
@@ -127,6 +129,11 @@ export default function Home() {
           status={gameStatus.status}
           lastError={lastError}
           showTimer={showTimer}
+          isGameOver={gameStatus.isGameOver}
+          outcome={gameStatus.outcome}
+          winner={gameStatus.winner}
+          idleSnark={idleSnark}
+          idleSnarkKey={idleSnarkIndex}
         />
 
         <PromotionDialog

--- a/src/components/GameStatus.tsx
+++ b/src/components/GameStatus.tsx
@@ -1,35 +1,111 @@
 import React from "react";
+import type { GameOutcome } from "../lib/chess";
 
 interface GameStatusProps {
   status: string;
   lastError?: string;
   showTimer?: boolean;
+  isGameOver?: boolean;
+  outcome?: GameOutcome;
+  winner?: "white" | "black" | null;
+  idleSnark?: string | null;
+  /** Increments each time the player puts a piece back; drives carousel animation */
+  idleSnarkKey?: number | null;
 }
 
 export const GameStatus: React.FC<GameStatusProps> = ({
   status,
   lastError,
   showTimer = false,
+  isGameOver = false,
+  outcome = null,
+  winner = null,
+  idleSnark = null,
+  idleSnarkKey = null,
 }) => {
-  // Hide regular status when timer is shown for "to move" states
-  const shouldShowStatus =
-    !showTimer ||
-    (!status.includes("to move") && !status.includes("is in check"));
+  const showGameOverBanner = Boolean(isGameOver && outcome);
+  const showRegularStatusRow =
+    !showGameOverBanner &&
+    (!showTimer ||
+      (!status.includes("to move") && !status.includes("is in check")));
+
+  const winnerLabel = winner === "white" ? "White" : "Black";
 
   return (
     <div
+      className="game-status-root"
       style={{
         fontSize: 14,
         textAlign: "center",
-        minHeight: shouldShowStatus ? "auto" : "0",
+        width: "100%",
+        maxWidth: 560,
       }}
     >
-      {shouldShowStatus && (
+      {showGameOverBanner && (
+        <div
+          className={
+            outcome === "checkmate"
+              ? "game-over-banner game-over-banner--checkmate"
+              : outcome === "stalemate"
+                ? "game-over-banner game-over-banner--stalemate"
+                : "game-over-banner game-over-banner--draw"
+          }
+          role="status"
+          aria-live="polite"
+        >
+          {outcome === "checkmate" && winner && (
+            <>
+              <div className="game-over-banner__icon" aria-hidden>
+                ♔
+              </div>
+              <div className="game-over-banner__title">Checkmate</div>
+              <div className="game-over-banner__winner">
+                {winnerLabel} wins
+              </div>
+            </>
+          )}
+          {outcome === "stalemate" && (
+            <>
+              <div className="game-over-banner__icon" aria-hidden>
+                ♔
+              </div>
+              <div className="game-over-banner__title">Stalemate</div>
+              <div className="game-over-banner__sub">Draw — no legal moves</div>
+            </>
+          )}
+          {outcome === "draw" && (
+            <>
+              <div className="game-over-banner__icon" aria-hidden>
+                🤝
+              </div>
+              <div className="game-over-banner__title">Draw</div>
+              <div className="game-over-banner__sub">Game over</div>
+            </>
+          )}
+        </div>
+      )}
+
+      {showRegularStatusRow && (
         <div style={{ marginBottom: 4 }}>
           <strong>Status:</strong> {status}
         </div>
       )}
-      {lastError && <div className="error-message">⚠️ {lastError}</div>}
+
+      {lastError && (
+        <div className="error-message" role="alert">
+          ⚠️ {lastError}
+        </div>
+      )}
+
+      {!lastError && idleSnark && !isGameOver && (
+        <div
+          className="idle-snark-carousel"
+          key={idleSnarkKey ?? idleSnark}
+          role="status"
+        >
+          <p className="idle-snark-carousel__text">{idleSnark}</p>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/lib/chess.ts
+++ b/src/lib/chess.ts
@@ -42,11 +42,47 @@ export type PieceSymbols = {
   [key: string]: string;
 };
 
+export type GameOutcome = "checkmate" | "draw" | "stalemate" | null;
+
 export type GameStatus = {
   status: string;
   turnColor: string;
   inCheck: boolean;
   isGameOver: boolean;
+  outcome: GameOutcome;
+  /** Side that won; only set when outcome is checkmate */
+  winner: "white" | "black" | null;
+};
+
+/** Shown when the player picks up a piece and puts it back on the same square */
+export const IDLE_SNARKS: readonly string[] = [
+  "Changed your mind? The board saw that.",
+  "Indecision is a move too — just not a legal one.",
+  "The pieces appreciate the stretch. Still your turn.",
+  "Bold strategy: hover menacingly, then retreat.",
+  "That square was lonely for a reason.",
+  "You almost had a plan. Emphasis on almost.",
+  "The king is still waiting. No rush. (There is rush.)",
+  "Plot twist: nobody moved.",
+  "Schrodinger's move: simultaneously brave and cancelled.",
+  "We'll call that a rehearsal. Break a leg next time.",
+];
+
+/**
+ * Random index into {@link IDLE_SNARKS}, never the same as `previous` when at least two lines exist.
+ * One shared value per game so both players see the same quip.
+ */
+export const pickNextIdleSnarkIndex = (previous: number | null): number => {
+  const n = IDLE_SNARKS.length;
+  if (n <= 1) return 0;
+  if (previous === null) {
+    return Math.floor(Math.random() * n);
+  }
+  let next: number;
+  do {
+    next = Math.floor(Math.random() * n);
+  } while (next === previous);
+  return next;
 };
 
 // ===== CONSTANTS =====

--- a/src/lib/useChessGame.ts
+++ b/src/lib/useChessGame.ts
@@ -10,12 +10,16 @@ import {
   isPromotion,
   generateMoveErrorMessage,
   BOARD_STYLES,
+  IDLE_SNARKS,
+  pickNextIdleSnarkIndex,
 } from "./chess";
 
 export const useChessGame = () => {
   // Game state
   const [fen, setFen] = useState<string>(new Chess().fen());
   const [lastError, setLastError] = useState<string>("");
+  /** Index into IDLE_SNARKS; null means hide idle snark */
+  const [idleSnarkIndex, setIdleSnarkIndex] = useState<number | null>(null);
   const [moveFrom, setMoveFrom] = useState<string>("");
   const [showPromotionDialog, setShowPromotionDialog] =
     useState<boolean>(false);
@@ -42,10 +46,20 @@ export const useChessGame = () => {
     const isGameOver = game.isGameOver();
 
     let status: string;
+    let outcome: GameStatus["outcome"] = null;
+    let winner: GameStatus["winner"] = null;
+
     if (isGameOver) {
       if (game.isCheckmate()) {
-        status = `Checkmate! ${turnColor === "White" ? "Black" : "White"} wins`;
+        outcome = "checkmate";
+        winner = game.turn() === "w" ? "black" : "white";
+        const winnerLabel = winner === "white" ? "White" : "Black";
+        status = `Checkmate — ${winnerLabel} wins`;
+      } else if (game.isStalemate()) {
+        outcome = "stalemate";
+        status = "Stalemate — draw";
       } else if (game.isDraw()) {
+        outcome = "draw";
         status = "Draw";
       } else {
         status = "Game over";
@@ -56,7 +70,7 @@ export const useChessGame = () => {
       status = `${turnColor} to move`;
     }
 
-    return { status, turnColor, inCheck, isGameOver };
+    return { status, turnColor, inCheck, isGameOver, outcome, winner };
   }, [game]);
 
   // Update captured pieces when FEN changes
@@ -118,6 +132,7 @@ export const useChessGame = () => {
   const makeMove = useCallback(
     (move: Move): boolean => {
       setLastError("");
+      setIdleSnarkIndex(null);
       const gameInstance = new Chess(fen);
 
       try {
@@ -159,7 +174,18 @@ export const useChessGame = () => {
       sourceSquare: string;
       targetSquare: string | null;
     }): boolean => {
-      if (!targetSquare) return false;
+      if (!targetSquare) {
+        setMoveFrom("");
+        return false;
+      }
+
+      // Putting the piece back — not an invalid move; random snark (not a repeat of last)
+      if (sourceSquare === targetSquare) {
+        setLastError("");
+        setIdleSnarkIndex((prev) => pickNextIdleSnarkIndex(prev));
+        setMoveFrom("");
+        return true;
+      }
 
       // Validate turn before attempting the move
       const gameInstance = new Chess(fen);
@@ -167,6 +193,7 @@ export const useChessGame = () => {
 
       if (!piece) {
         setLastError(`No piece on ${sourceSquare.toUpperCase()}`);
+        setIdleSnarkIndex(null);
         return false;
       }
 
@@ -175,6 +202,7 @@ export const useChessGame = () => {
         setLastError(
           `It's ${gameInstance.turn() === "w" ? "White" : "Black"}'s turn`
         );
+        setIdleSnarkIndex(null);
         return false;
       }
 
@@ -251,6 +279,7 @@ export const useChessGame = () => {
           setMoveFrom(square);
         } else if (clickedPiece) {
           // Show error when trying to select opponent's piece
+          setIdleSnarkIndex(null);
           setLastError(
             `It's ${gameInstance.turn() === "w" ? "White" : "Black"}'s turn`
           );
@@ -321,6 +350,7 @@ export const useChessGame = () => {
     const fresh = new Chess();
     setFen(fresh.fen());
     setLastError("");
+    setIdleSnarkIndex(null);
     setMoveFrom("");
     setShowPromotionDialog(false);
     setPendingMove(null);
@@ -342,6 +372,9 @@ export const useChessGame = () => {
     fen,
     gameStatus,
     lastError,
+    idleSnarkIndex,
+    idleSnark:
+      idleSnarkIndex === null ? null : IDLE_SNARKS[idleSnarkIndex],
     capturedPieces,
     customSquareStyles,
 


### PR DESCRIPTION
This PR improves end-game feedback and how we treat putting a piece back on its original square.

**Game over**
- Large banners for checkmate (winner), stalemate, and draw so results are easy to see at a glance.

**Same-square drop (cancel move)**
- No longer shown as an invalid move; shows a random idle quip from a shared list, never repeating the line just shown (when multiple lines exist).

**UI**
- Removed the "Note" label above snark text; kept styling consistent with the rest of the app.