### PR TITLE
fix(ui): mobile timer banner stays in one row

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -569,18 +569,24 @@ body {
 @media (max-width: 480px) {
   .timer-banner {
     padding: 10px 12px;
-    gap: 8px;
-    flex-wrap: wrap;
+    gap: 6px;
+    flex-wrap: nowrap;
+    align-items: center;
     min-height: 0;
   }
 
   .timer-section {
-    padding: 0 4px;
-    flex: 1 1 50%;
+    padding: 0 2px;
+    flex: 1 1 0;
+    min-width: 0;
   }
 
   .timer-header {
-    gap: 4px;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 6px;
     margin-bottom: 4px;
   }
 
@@ -589,9 +595,9 @@ body {
   }
 
   .timer-value {
-    font-size: 18px;
-    padding: 4px 8px;
-    min-width: 64px;
+    font-size: 16px;
+    padding: 4px 6px;
+    min-width: 0;
   }
 
   .material-points {
@@ -600,17 +606,22 @@ body {
   }
 
   .turn-indicator {
-    order: 3;
-    flex-basis: 100%;
-    padding: 4px 0 0;
+    flex-direction: row;
+    flex: 0 1 auto;
+    min-width: 0;
+    padding: 0 4px;
+    gap: 6px;
   }
 
   .turn-text {
-    font-size: 10px;
+    font-size: 9px;
+    max-width: 56px;
+    line-height: 1.15;
   }
 
   .turn-dot {
     width: 10px;
     height: 10px;
+    flex-shrink: 0;
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -254,11 +254,13 @@ body {
   margin-bottom: 8px;
 }
 
-/* Timer Banner */
+/* Timer Banner — 1fr | auto | 1fr keeps the turn indicator truly centered */
 .timer-banner {
-  display: flex;
-  align-items: stretch;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  justify-items: center;
+  column-gap: 12px;
   width: 100%;
   max-width: 560px;
   padding: 16px 20px;
@@ -278,10 +280,14 @@ body {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  flex: 1;
+  align-items: center;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   opacity: 0.7;
   transition: all 0.3s ease;
-  padding: 0 8px;
+  padding: 0 4px;
+  justify-self: stretch;
 }
 
 .timer-section.active {
@@ -334,8 +340,10 @@ body {
   align-items: center;
   justify-content: center;
   gap: 8px;
-  padding: 0 16px;
-  flex: 0 0 auto;
+  padding: 0 8px;
+  justify-self: center;
+  align-self: center;
+  text-align: center;
 }
 
 .turn-dot {
@@ -568,17 +576,15 @@ body {
 
 @media (max-width: 480px) {
   .timer-banner {
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    column-gap: 8px;
     padding: 10px 12px;
-    gap: 6px;
-    flex-wrap: nowrap;
-    align-items: center;
     min-height: 0;
+    align-items: center;
   }
 
   .timer-section {
     padding: 0 2px;
-    flex: 1 1 0;
-    min-width: 0;
   }
 
   .timer-header {
@@ -588,6 +594,7 @@ body {
     flex-wrap: wrap;
     gap: 6px;
     margin-bottom: 4px;
+    width: 100%;
   }
 
   .timer-label {
@@ -607,16 +614,17 @@ body {
 
   .turn-indicator {
     flex-direction: row;
-    flex: 0 1 auto;
-    min-width: 0;
-    padding: 0 4px;
+    align-items: center;
+    justify-content: center;
+    padding: 0 6px;
     gap: 6px;
   }
 
   .turn-text {
     font-size: 9px;
-    max-width: 56px;
+    max-width: 72px;
     line-height: 1.15;
+    text-align: center;
   }
 
   .turn-dot {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -263,7 +263,7 @@ body {
   column-gap: 12px;
   width: 100%;
   max-width: 560px;
-  padding: 16px 20px;
+  padding: 18px 20px;
   background: linear-gradient(
     135deg,
     var(--card-bg) 0%,
@@ -273,7 +273,7 @@ body {
   border-radius: 12px;
   margin-bottom: 12px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
-  min-height: 80px;
+  box-sizing: border-box;
 }
 
 .timer-section {
@@ -281,18 +281,22 @@ body {
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  gap: 8px;
   width: 100%;
   max-width: 100%;
   min-width: 0;
   opacity: 0.7;
-  transition: all 0.3s ease;
+  transition:
+    opacity 0.3s ease,
+    box-shadow 0.3s ease;
   padding: 0 4px;
   justify-self: stretch;
+  align-self: center;
 }
 
 .timer-section.active {
   opacity: 1;
-  transform: scale(1.02);
+  filter: brightness(1.06);
 }
 
 .timer-header {
@@ -300,7 +304,6 @@ body {
   flex-direction: column;
   align-items: center;
   gap: 6px;
-  margin-bottom: 8px;
 }
 
 .timer-label {
@@ -308,6 +311,7 @@ body {
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 1px;
+  line-height: 1.15;
   color: var(--muted);
 }
 
@@ -341,8 +345,7 @@ body {
   justify-content: center;
   gap: 8px;
   padding: 0 8px;
-  justify-self: center;
-  align-self: center;
+  place-self: center;
   text-align: center;
 }
 
@@ -376,12 +379,15 @@ body {
   line-height: 1.2;
 }
 
-/* Material Section */
+/* Material Section — no reserved strip when empty (avoids top-heavy clocks) */
 .material-section {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 4px;
+}
+
+.material-section:not(:empty) {
   min-height: 24px;
 }
 
@@ -578,13 +584,13 @@ body {
   .timer-banner {
     grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
     column-gap: 8px;
-    padding: 10px 12px;
-    min-height: 0;
+    padding: 14px 12px;
     align-items: center;
   }
 
   .timer-section {
     padding: 0 2px;
+    gap: 6px;
   }
 
   .timer-header {
@@ -593,7 +599,6 @@ body {
     justify-content: center;
     flex-wrap: wrap;
     gap: 6px;
-    margin-bottom: 4px;
     width: 100%;
   }
 


### PR DESCRIPTION
Keeps the timer banner horizontal on small screens: no full-width wrapped turn indicator, nowrap flex layout, row-oriented labels/times and compact turn indicator.